### PR TITLE
Add unit test for database

### DIFF
--- a/grouping_server/database/models.py
+++ b/grouping_server/database/models.py
@@ -82,14 +82,14 @@ class UserTag(models.Model):
 
 
 class Workspace(models.Model):
-    theme_color = models.IntegerField()
-    workspace_name = models.CharField(max_length=20)
-    description = models.TextField()
+    theme_color = models.IntegerField(verbose_name="主題顏色")
+    workspace_name = models.CharField(max_length=20,verbose_name="名稱")
+    description = models.TextField(verbose_name="簡介")
     is_personal = models.BooleanField()
     photo = models.ForeignKey(
-        Image, null=True, blank=True, on_delete=models.SET_NULL)
+        Image, null=True, blank=True, on_delete=models.SET_NULL,verbose_name="頭像")
     members = models.ManyToManyField(
-        User, related_name='joined_workspaces')
+        User, related_name='joined_workspaces',verbose_name="成員")
 
 
 class WorkspaceTag(models.Model):

--- a/grouping_server/database/models.py
+++ b/grouping_server/database/models.py
@@ -105,7 +105,7 @@ class MissionState(models.Model):
         CLOSE = 'CLOSE', _('close')
     stage = models.CharField(
         max_length=15, choices=Stage.choices, default=Stage.IN_PROGRESS)
-    name = models.CharField(max_length=20)
+    name = models.CharField(max_length=20, verbose_name="名稱")
     belong_workspace = models.ForeignKey(Workspace, on_delete=models.CASCADE)
 
 

--- a/grouping_server/database/models.py
+++ b/grouping_server/database/models.py
@@ -83,19 +83,19 @@ class UserTag(models.Model):
 
 class Workspace(models.Model):
     theme_color = models.IntegerField(verbose_name="主題顏色")
-    workspace_name = models.CharField(max_length=20,verbose_name="名稱")
+    workspace_name = models.CharField(max_length=20, verbose_name="名稱")
     description = models.TextField(verbose_name="簡介")
     is_personal = models.BooleanField()
     photo = models.ForeignKey(
-        Image, null=True, blank=True, on_delete=models.SET_NULL,verbose_name="頭像")
+        Image, null=True, blank=True, on_delete=models.SET_NULL, verbose_name="頭像")
     members = models.ManyToManyField(
-        User, related_name='joined_workspaces',verbose_name="成員")
+        User, related_name='joined_workspaces', verbose_name="成員")
 
 
 class WorkspaceTag(models.Model):
     belong_workspace = models.ForeignKey(
         Workspace, on_delete=models.CASCADE, related_name='tags')
-    content = models.CharField(max_length=20)
+    content = models.CharField(max_length=20, verbose_name="內容")
 
 
 class MissionState(models.Model):

--- a/grouping_server/database/models.py
+++ b/grouping_server/database/models.py
@@ -77,8 +77,8 @@ class User(AbstractBaseUser, PermissionsMixin):
 class UserTag(models.Model):
     belong_user = models.ForeignKey(
         User, on_delete=models.CASCADE, related_name='tags')
-    title = models.CharField(max_length=20)
-    content = models.CharField(max_length=20)
+    title = models.CharField(max_length=20, verbose_name="標題")
+    content = models.CharField(max_length=20, verbose_name="內容")
 
 
 class Workspace(models.Model):

--- a/grouping_server/database/tests.py
+++ b/grouping_server/database/tests.py
@@ -5,7 +5,7 @@ import os
 from django.test import override_settings
 from django.conf import settings
 from database.models import User, Image, UserTag, Workspace, WorkspaceTag, \
-    MissionState, Activity, ActivityNotification
+    MissionState, Activity, ActivityNotification, Event, Mission
 from django.db.utils import IntegrityError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
@@ -412,3 +412,40 @@ class ActivityNotificationTest(TestCase):
         self.activity.delete()
         with self.assertRaises(ActivityNotification.DoesNotExist):
             ActivityNotification.objects.get(id=self.notification.id)
+
+
+class EventTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create()
+        cls.workspace = Workspace.objects.create(
+            theme_color=0, is_personal=True)
+        cls.activity = Activity.objects.create(
+            creator=cls.user, belong_workspace=cls.workspace)
+        cls.event = Event.objects.create(
+            belong_activity=cls.activity,
+            start_time=timezone.datetime(2023, 1, 1, tzinfo=timezone.utc),
+            end_time=timezone.datetime(2023, 1, 1, tzinfo=timezone.utc))
+
+    def test_cascade_delete_activity(self):
+        self.activity.delete()
+        with self.assertRaises(Event.DoesNotExist):
+            Event.objects.get(belong_activity=self.activity)
+
+
+class MissionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create()
+        cls.workspace = Workspace.objects.create(
+            theme_color=0, is_personal=True)
+        cls.activity = Activity.objects.create(
+            creator=cls.user, belong_workspace=cls.workspace)
+        cls.mission = Mission.objects.create(
+            belong_activity=cls.activity,
+            deadline=timezone.datetime(2023, 1, 1, tzinfo=timezone.utc))
+
+    def test_cascade_delete_activity(self):
+        self.activity.delete()
+        with self.assertRaises(Mission.DoesNotExist):
+            Mission.objects.get(belong_activity=self.activity)

--- a/grouping_server/database/tests.py
+++ b/grouping_server/database/tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 import os
 from django.test import override_settings
 from django.conf import settings
-from database.models import User, Image, UserTag, Workspace, WorkspaceTag
+from database.models import User, Image, UserTag, Workspace, WorkspaceTag, MissionState
 from django.db.utils import IntegrityError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
@@ -276,3 +276,49 @@ class WorkspaceTagModelTest(TestCase):
         self.workspace.delete()
         with self.assertRaises(WorkspaceTag.DoesNotExist):
             WorkspaceTag.objects.get(id=self.tag.id)
+
+
+class MissionStateModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Create a Workspace instance for testing
+        cls.workspace = Workspace.objects.create(
+            theme_color=0, is_personal=True)
+
+        # Create a MissionState instance for testing
+        cls.mission_state = MissionState.objects.create(
+            stage=MissionState.Stage.IN_PROGRESS,
+            name='Test Mission State',
+            belong_workspace=cls.workspace,
+        )
+
+    def test_mission_state_creation(self):
+        # Check that the mission state was created correctly
+        self.assertTrue(self.mission_state.id)
+        self.assertEqual(self.mission_state.stage, MissionState.Stage.IN_PROGRESS)
+        self.assertEqual(self.mission_state.name, 'Test Mission State')
+        self.assertEqual(self.mission_state.belong_workspace, self.workspace)
+
+    def test_default_stage(self):
+        # Create another MissionState instance without specifying the stage
+        new_mission_state = MissionState.objects.create(
+            name='Another Mission State',
+            belong_workspace=self.workspace,
+        )
+
+        # Check that the default stage is set for the new instance
+        self.assertEqual(new_mission_state.stage,
+                         MissionState.Stage.IN_PROGRESS)
+
+    def test_name_max_length(self):
+        max_length = self.mission_state._meta.get_field('name').max_length
+        self.assertEquals(max_length, 20)
+
+    def test_name_label(self):
+        field_label = self.mission_state._meta.get_field('name').verbose_name
+        self.assertEquals(field_label, '名稱')
+        
+    def test_cascade_delete_workspace(self):
+        self.workspace.delete()
+        with self.assertRaises(MissionState.DoesNotExist):
+            MissionState.objects.get(id=self.mission_state.id)

--- a/grouping_server/grouping_server/settings.py
+++ b/grouping_server/grouping_server/settings.py
@@ -185,3 +185,4 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+UNIT_TEST_ROOT = os.path.join(BASE_DIR, 'unit_test_data')

--- a/grouping_server/requirements.txt
+++ b/grouping_server/requirements.txt
@@ -30,3 +30,4 @@ typing_extensions==4.7.1
 tzdata==2023.3
 uritemplate==4.1.1
 urllib3==1.26.16
+freezegun==1.2.2


### PR DESCRIPTION
1. The unit test for User was already merged into main. But might need @Dilamissu to check out if there are some missing test case for field like "is_staff" or "is_superuser".
2. Add unit test for UserTag, Image, Workspace, WorkspaceTag, MissionState, Activity, ActivityNotification, Event, Mission.
3. Add UNIT_TEST_ROOT in settings, in order to store all file data generated during running test. 
    !!!Notice!!! :
    (1) All files and folders generating during running test should be store in UNIT_TEST_ROOT, for example, using `@override_settings(MEDIA_ROOT=settings.UNIT_TEST_ROOT)` before `class ImageModelTest(TestCase):`.
    (2) All files and folders in UNIT_TEST_ROOT should be deleted after running test, and this action should be done by manually writing codes in tearDownClass function, or other ways that can be automatically execute.